### PR TITLE
Fix missing audio buttons in week3 quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,38 +478,38 @@ summary { font-weight: bold; }
             <ol>
               <li>
                 <p>Why sketch multiple ideas? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
-                <label><input name="main_q3_1" type="radio" value="Waste" /> It's a waste of time</label><br />
-                <label><input data-correct="true" name="main_q3_1" type="radio" value="Compare" /> To compare and pick the best parts</label><br />
-                <label><input name="main_q3_1" type="radio" value="Bonus" /> For extra marks</label><br />
-                <label><input name="main_q3_1" type="radio" value="Confuse" /> To confuse the teacher</label>
+                <label><input name="main_q3_1" type="radio" value="Waste" /> It's a waste of time <button aria-label="Read answer It's a waste of time" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input data-correct="true" name="main_q3_1" type="radio" value="Compare" /> To compare and pick the best parts <button aria-label="Read answer To compare and pick the best parts" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_1" type="radio" value="Bonus" /> For extra marks <button aria-label="Read answer For extra marks" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_1" type="radio" value="Confuse" /> To confuse the teacher <button aria-label="Read answer To confuse the teacher" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
               </li>
               <li>
                 <p>What belongs on a detailed design drawing? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
-                <label><input name="main_q3_2" type="radio" value="Pictures" /> Only pictures</label><br />
-                <label><input data-correct="true" name="main_q3_2" type="radio" value="Labels" /> Labels and measurements</label><br />
-                <label><input name="main_q3_2" type="radio" value="Tools" /> A list of tools</label><br />
-                <label><input name="main_q3_2" type="radio" value="Names" /> Classmate names</label>
+                <label><input name="main_q3_2" type="radio" value="Pictures" /> Only pictures <button aria-label="Read answer Only pictures" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input data-correct="true" name="main_q3_2" type="radio" value="Labels" /> Labels and measurements <button aria-label="Read answer Labels and measurements" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_2" type="radio" value="Tools" /> A list of tools <button aria-label="Read answer A list of tools" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_2" type="radio" value="Names" /> Classmate names <button aria-label="Read answer Classmate names" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
               </li>
               <li>
                 <p>You have a complex design and a simple design that meets the brief. What should you do? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
-                <label><input name="main_q3_3" type="radio" value="Complex" /> Pick the complex one</label><br />
-                <label><input data-correct="true" name="main_q3_3" type="radio" value="Simple" /> Choose the simpler one if you're a beginner</label><br />
-                <label><input name="main_q3_3" type="radio" value="Both" /> Build both</label><br />
-                <label><input name="main_q3_3" type="radio" value="Random" /> Ask a friend to choose randomly</label>
+                <label><input name="main_q3_3" type="radio" value="Complex" /> Pick the complex one <button aria-label="Read answer Pick the complex one" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input data-correct="true" name="main_q3_3" type="radio" value="Simple" /> Choose the simpler one if you're a beginner <button aria-label="Read answer Choose the simpler one if you're a beginner" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_3" type="radio" value="Both" /> Build both <button aria-label="Read answer Build both" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_3" type="radio" value="Random" /> Ask a friend to choose randomly <button aria-label="Read answer Ask a friend to choose randomly" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
               </li>
               <li>
                 <p>What does drawing to scale mean? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
-                <label><input name="main_q3_4" type="radio" value="Life" /> Drawing it life-size</label><br />
-                <label><input data-correct="true" name="main_q3_4" type="radio" value="Proportion" /> Drawing parts in the correct proportions</label><br />
-                <label><input name="main_q3_4" type="radio" value="Weight" /> Measuring your weight</label><br />
-                <label><input name="main_q3_4" type="radio" value="Notebook" /> Only drawing in a small notebook</label>
+                <label><input name="main_q3_4" type="radio" value="Life" /> Drawing it life-size <button aria-label="Read answer Drawing it life-size" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input data-correct="true" name="main_q3_4" type="radio" value="Proportion" /> Drawing parts in the correct proportions <button aria-label="Read answer Drawing parts in the correct proportions" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_4" type="radio" value="Weight" /> Measuring your weight <button aria-label="Read answer Measuring your weight" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_4" type="radio" value="Notebook" /> Only drawing in a small notebook <button aria-label="Read answer Only drawing in a small notebook" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
               </li>
               <li>
                 <p>Considering a classmate's suggestion about marker pen size is an example of which step? <button aria-label="Read question aloud" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></p>
-                <label><input name="main_q3_5" type="radio" value="Ignore" /> Ignoring feedback</label><br />
-                <label><input data-correct="true" name="main_q3_5" type="radio" value="Evaluate" /> Evaluating and refining the design</label><br />
-                <label><input name="main_q3_5" type="radio" value="Build" /> Production</label><br />
-                <label><input name="main_q3_5" type="radio" value="Brief" /> Writing the design brief</label>
+                <label><input name="main_q3_5" type="radio" value="Ignore" /> Ignoring feedback <button aria-label="Read answer Ignoring feedback" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input data-correct="true" name="main_q3_5" type="radio" value="Evaluate" /> Evaluating and refining the design <button aria-label="Read answer Evaluating and refining the design" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_5" type="radio" value="Build" /> Production <button aria-label="Read answer Production" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label><br />
+                <label><input name="main_q3_5" type="radio" value="Brief" /> Writing the design brief <button aria-label="Read answer Writing the design brief" onclick="event.preventDefault(); speakText(this)" type="button">🔊</button></label>
               </li>
             </ol>
             <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 3')">Check Answers</button>


### PR DESCRIPTION
## Summary
- add speaker buttons for Week 3 quiz answers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a6d84d3d883269df866f5bdbd88a7