### PR TITLE
Fix week 9 section markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,7 +924,6 @@ summary { font-weight: bold; }
       </article>
     </details>
     <details>
-<details>
   <summary><b>Week 9: Finishing and Evaluating</b></summary>
   <article>
     <h4>Final Finishes</h4>
@@ -980,6 +979,7 @@ summary { font-weight: bold; }
     <p>A smooth finish and honest evaluation make your desk tidy look professional and help you learn for future projects.</p>
   </article>
 </details>
+    <details>
       <summary><b>Week 10: Finishing Touches and Presentation</b></summary>
       <article>
         <p>In the final week, give your desk tidy a smooth finish and prepare


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in `index.html`
- restore Week 9 details block
- add missing `<details>` tag before Week 10 summary

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a8a2deb1c83268bbf63bec14398eb