### PR TITLE
Remove bold from quiz answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,6 @@
     /* Styles for quiz feedback */
     .quiz label[data-result="right"] {
         color: green;
-        font-weight: bold;
     }
     .quiz label[data-result="wrong"] {
         color: red;


### PR DESCRIPTION
## Summary
- adjust CSS so quiz answers no longer become bold when marked correct

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aae366f88832695c5e586d33dff7a