### PR TITLE
Add aria labels for quiz audio buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2350,6 +2350,12 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('resultPopup').classList.remove('active');
     });
   }
+  // Ensure all quiz question buttons have an aria-label
+  document.querySelectorAll('form.quiz li > p button').forEach(btn => {
+    if (!btn.hasAttribute('aria-label')) {
+      btn.setAttribute('aria-label', 'Read question aloud');
+    }
+  });
   // Add audio buttons after each quiz answer if missing
   document.querySelectorAll('form.quiz label').forEach(label => {
     if (!label.querySelector('button')) {


### PR DESCRIPTION
## Summary
- ensure quiz question buttons have an accessible `aria-label`
- leave existing script that adds answer buttons intact

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ab04b816c8326a07e4b82a704dde1