### PR TITLE
Remove bold styling from quiz answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,9 @@
     .quiz li {
       font-weight: normal;
     }
+    .quiz label {
+      font-weight: normal;
+    }
     .resource-links a {
       font-weight: bold;
     }


### PR DESCRIPTION
## Summary
- ensure quiz answers display in normal weight

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ab15c97408326a6b45438a0bf978e