### PR TITLE
Randomize quiz answer order

### DIFF
--- a/index.html
+++ b/index.html
@@ -2370,7 +2370,25 @@ function askForName() {
   });
 }
 
+function shuffleQuizAnswers() {
+  document.querySelectorAll('form.quiz li').forEach(li => {
+    const labels = Array.from(li.querySelectorAll('label'));
+    if (labels.length <= 1) return;
+    li.querySelectorAll('br').forEach(br => br.remove());
+    labels.forEach(l => l.remove());
+    for (let i = labels.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [labels[i], labels[j]] = [labels[j], labels[i]];
+    }
+    labels.forEach((label, idx) => {
+      li.appendChild(label);
+      if (idx < labels.length - 1) li.appendChild(document.createElement('br'));
+    });
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  shuffleQuizAnswers();
   const closeBtn = document.querySelector('#resultPopup .close-popup');
   if (closeBtn) {
     closeBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- randomize the order of quiz answers on each page load
- call the new function when DOM loads

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ae8641c9083269c6c379a168865b5