### PR TITLE
Fix quiz correctness bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,82 +510,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q1_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q1_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q1_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q1_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q1_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q1_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q1_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q1_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q1_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q1_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q1_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q1_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q1_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q1_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q1_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q1_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q1_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q1_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q1_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q1_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q1_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q1_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q1_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q1_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q1_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q1_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q1_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q1_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q1_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q1_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q1_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q1_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q1_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q1_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q1_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q1_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q1_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q1_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q1_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q1_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q1_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q1_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q1_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q1_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q1_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q1_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q1_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q1_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q1_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q1_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q1_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q1_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q1_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q1_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q1_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q1_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q1_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q1_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q1_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q1_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q1_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q1_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q1_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q1_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q1_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q1_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q1_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q1_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q1_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q1_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 1')">Check Answers</button>
@@ -612,82 +612,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q2_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q2_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q2_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q2_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q2_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q2_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q2_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q2_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q2_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q2_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q2_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q2_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q2_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q2_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q2_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q2_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q2_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q2_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q2_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q2_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q2_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q2_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q2_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q2_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q2_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q2_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q2_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q2_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q2_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q2_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q2_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q2_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q2_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q2_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q2_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q2_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q2_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q2_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q2_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q2_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q2_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q2_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q2_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q2_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q2_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q2_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q2_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q2_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q2_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q2_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q2_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q2_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q2_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q2_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q2_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q2_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q2_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q2_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q2_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q2_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q2_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q2_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q2_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q2_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q2_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q2_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q2_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q2_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q2_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q2_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 2')">Check Answers</button>
@@ -717,82 +717,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q3_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q3_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q3_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q3_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q3_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q3_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q3_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q3_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q3_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q3_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q3_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q3_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q3_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q3_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q3_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q3_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q3_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q3_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q3_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q3_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q3_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q3_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q3_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q3_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q3_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q3_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q3_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q3_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q3_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q3_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q3_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q3_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q3_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q3_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q3_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q3_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q3_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q3_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q3_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q3_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q3_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q3_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q3_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q3_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q3_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q3_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q3_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q3_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q3_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q3_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q3_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q3_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q3_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q3_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q3_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q3_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q3_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q3_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q3_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q3_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q3_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q3_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q3_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q3_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q3_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q3_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q3_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q3_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q3_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q3_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 3')">Check Answers</button>
@@ -816,82 +816,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q4_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q4_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q4_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q4_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q4_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q4_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q4_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q4_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q4_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q4_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q4_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q4_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q4_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q4_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q4_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q4_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q4_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q4_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q4_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q4_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q4_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q4_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q4_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q4_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q4_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q4_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q4_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q4_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q4_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q4_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q4_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q4_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q4_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q4_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q4_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q4_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q4_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q4_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q4_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q4_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q4_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q4_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q4_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q4_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q4_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q4_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q4_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q4_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q4_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q4_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q4_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q4_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q4_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q4_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q4_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q4_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q4_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q4_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q4_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q4_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q4_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q4_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q4_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q4_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q4_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q4_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q4_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q4_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q4_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q4_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 4')">Check Answers</button>
@@ -939,82 +939,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q5_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q5_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q5_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q5_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q5_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q5_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q5_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q5_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q5_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q5_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q5_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q5_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q5_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q5_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q5_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q5_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q5_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q5_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q5_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q5_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q5_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q5_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q5_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q5_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q5_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q5_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q5_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q5_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q5_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q5_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q5_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q5_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q5_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q5_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q5_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q5_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q5_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q5_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q5_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q5_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q5_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q5_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q5_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q5_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q5_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q5_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q5_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q5_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q5_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q5_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q5_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q5_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q5_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q5_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q5_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q5_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q5_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q5_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q5_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q5_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q5_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q5_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q5_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q5_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q5_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q5_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q5_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q5_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q5_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q5_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 5')">Check Answers</button>
@@ -1053,82 +1053,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q6_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q6_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q6_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q6_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q6_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q6_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q6_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q6_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q6_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q6_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q6_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q6_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q6_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q6_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q6_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q6_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q6_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q6_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q6_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q6_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q6_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q6_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q6_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q6_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q6_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q6_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q6_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q6_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q6_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q6_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q6_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q6_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q6_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q6_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q6_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q6_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q6_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q6_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q6_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q6_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q6_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q6_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q6_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q6_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q6_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q6_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q6_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q6_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q6_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q6_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q6_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q6_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q6_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q6_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q6_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q6_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q6_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q6_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q6_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q6_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q6_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q6_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q6_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q6_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q6_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q6_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q6_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q6_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q6_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q6_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 6')">Check Answers</button>
@@ -1162,82 +1162,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q7_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q7_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q7_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q7_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q7_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q7_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q7_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q7_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q7_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q7_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q7_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q7_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q7_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q7_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q7_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q7_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q7_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q7_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q7_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q7_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q7_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q7_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q7_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q7_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q7_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q7_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q7_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q7_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q7_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q7_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q7_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q7_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q7_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q7_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q7_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q7_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q7_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q7_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q7_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q7_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q7_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q7_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q7_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q7_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q7_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q7_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q7_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q7_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q7_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q7_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q7_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q7_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q7_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q7_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q7_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q7_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q7_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q7_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q7_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q7_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q7_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q7_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q7_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q7_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q7_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q7_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q7_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q7_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q7_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q7_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 7')">Check Answers</button>
@@ -1264,82 +1264,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q8_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q8_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q8_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q8_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q8_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q8_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q8_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q8_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q8_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q8_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q8_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q8_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q8_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q8_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q8_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q8_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q8_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q8_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q8_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q8_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q8_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q8_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q8_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q8_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q8_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q8_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q8_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q8_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q8_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q8_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q8_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q8_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q8_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q8_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q8_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q8_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q8_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q8_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q8_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q8_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q8_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q8_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q8_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q8_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q8_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q8_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q8_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q8_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q8_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q8_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q8_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q8_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q8_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q8_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q8_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q8_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q8_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q8_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q8_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q8_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q8_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q8_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q8_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q8_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q8_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q8_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q8_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q8_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q8_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q8_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 8')">Check Answers</button>
@@ -1367,82 +1367,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q9_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q9_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q9_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q9_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q9_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q9_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q9_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q9_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q9_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q9_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q9_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q9_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q9_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q9_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q9_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q9_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q9_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q9_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q9_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q9_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q9_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q9_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q9_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q9_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q9_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q9_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q9_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q9_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q9_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q9_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q9_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q9_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q9_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q9_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q9_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q9_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q9_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q9_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q9_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q9_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q9_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q9_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q9_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q9_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q9_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q9_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q9_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q9_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q9_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q9_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q9_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q9_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q9_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q9_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q9_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q9_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q9_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q9_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q9_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q9_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q9_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q9_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q9_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q9_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q9_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q9_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q9_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q9_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q9_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q9_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 9')">Check Answers</button>
@@ -1481,82 +1481,82 @@ summary { font-weight: bold; }
       <li>
         <p><b>Scenario:</b> Alex walks into the workshop carrying a backpack filled with tools. He puts it down near the workbench and immediately grabs a saw without checking his surroundings.  
           Which of Alex’s actions is most likely to cause an accident?</p>
-        <label><input data-correct="false" name="main_q10_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
+        <label><input name="main_q10_1" type="radio" value="Putting backpack"/> A. Putting the backpack on the workbench without clearing away scrap wood first</label><br />
         <label><input data-correct="true" name="main_q10_1" type="radio" value="Grabbing saw"/> B. Grabbing the saw before checking that others have space to move around</label><br />
-        <label><input data-correct="false" name="main_q10_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
-        <label><input data-correct="false" name="main_q10_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
+        <label><input name="main_q10_1" type="radio" value="Safety glasses"/> C. Wearing safety glasses but not an apron</label><br />
+        <label><input name="main_q10_1" type="radio" value="Asking friend"/> D. Asking a friend to help carry the backpack later</label>
       </li>
       <li>
         <p><b>Scenario:</b> Before starting a cutting task, Mia notices a loose cord crossing the workshop floor and leaves it there because she plans to fix it later. She proceeds to measure her wood pieces.  
           Why is leaving the loose cord a safety hazard, and what should Mia do first?</p>
-        <label><input data-correct="false" name="main_q10_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
+        <label><input name="main_q10_2" type="radio" value="Cover with tape"/> A. It could fray—she should cover it with tape and continue measuring.</label><br />
         <label><input data-correct="true" name="main_q10_2" type="radio" value="Tape or move"/> B. Someone could trip—she should either tape it down or move it out of the walkway before measuring.</label><br />
-        <label><input data-correct="false" name="main_q10_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
-        <label><input data-correct="false" name="main_q10_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
+        <label><input name="main_q10_2" type="radio" value="Not dangerous"/> C. It’s not dangerous—measuring is more important, so she can fix it at break time.</label><br />
+        <label><input name="main_q10_2" type="radio" value="Ignore"/> D. It’s only an issue if water spills—ignore it for now and measure.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Jordan has long hair tied back but left some strands loose. He starts the power drill without re-securing them.  
           What could happen if Jordan continues drilling, and what’s the best preventive step?</p>
         <label><input data-correct="true" name="main_q10_3" type="radio" value="Hair caught"/> A. The loose strands could catch in the drill—re-tie the hair tightly before turning on the machine.</label><br />
-        <label><input data-correct="false" name="main_q10_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
-        <label><input data-correct="false" name="main_q10_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
-        <label><input data-correct="false" name="main_q10_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
+        <label><input name="main_q10_3" type="radio" value="Harmless"/> B. Loose strands are harmless—he should focus on gripping the drill correctly.</label><br />
+        <label><input name="main_q10_3" type="radio" value="Improve air"/> C. Loose strands improve air circulation—no need to change anything.</label><br />
+        <label><input name="main_q10_3" type="radio" value="Cut hair"/> D. The drill bit can cut the loose strands—he should wear gloves instead.</label>
       </li>
       <li>
         <p><b>Scenario:</b> During a demonstration, a student’s goggles slip off because they chose safety glasses that didn’t fit properly. They continue sanding without adjusting them.  
           Why is this a problem, and what should the student do immediately?</p>
         <label><input data-correct="true" name="main_q10_4" type="radio" value="Adjust or replace"/> A. They risk eye injury; they should stop and adjust or replace the goggles before resuming.</label><br />
-        <label><input data-correct="false" name="main_q10_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
-        <label><input data-correct="false" name="main_q10_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
-        <label><input data-correct="false" name="main_q10_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
+        <label><input name="main_q10_4" type="radio" value="Hold goggles"/> B. They can just hold the goggles in place with one hand; continue sanding.</label><br />
+        <label><input name="main_q10_4" type="radio" value="Particles harmless"/> C. Small wood particles won’t harm without goggles; keep sanding.</label><br />
+        <label><input name="main_q10_4" type="radio" value="Teacher finish"/> D. The teacher should finish the sanding instead; they can watch.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Sam spots a piece of scrap timber lying in the middle of the workshop floor but decides to leave it until the end of class to avoid interrupting the activity flow.  
           What makes this decision unsafe, and what is the correct action?</p>
         <label><input data-correct="true" name="main_q10_5" type="radio" value="Move to bin"/> A. It’s clutter—he should move the timber to a designated scrap bin immediately to prevent tripping.</label><br />
-        <label><input data-correct="false" name="main_q10_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
-        <label><input data-correct="false" name="main_q10_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
-        <label><input data-correct="false" name="main_q10_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
+        <label><input name="main_q10_5" type="radio" value="Not urgent"/> B. It’s not urgent—waiting until the end of class is acceptable.</label><br />
+        <label><input name="main_q10_5" type="radio" value="Teacher only"/> C. Only the teacher can pick up scrap—he should keep working.</label><br />
+        <label><input name="main_q10_5" type="radio" value="Keep as scrap"/> D. It’s useful scrap—he can leave it and pick it up later.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Lee notices that the bench’s power outlets have exposed wires under the counter, but he continues working on his project without reporting it.  
           Why is ignoring exposed wiring risky, and what is the proper immediate step?</p>
-        <label><input data-correct="false" name="main_q10_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
+        <label><input name="main_q10_6" type="radio" value="Check wetness"/> A. Exposed wires only pose a hazard if wet—he should check if it’s damp first.</label><br />
         <label><input data-correct="true" name="main_q10_6" type="radio" value="Inform teacher"/> B. Exposed wires risk electrocution; he should inform the teacher immediately and keep a safe distance until it’s fixed.</label><br />
-        <label><input data-correct="false" name="main_q10_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
-        <label><input data-correct="false" name="main_q10_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
+        <label><input name="main_q10_6" type="radio" value="Plug in drill"/> C. He should plug his drill in regardless—tools need power.</label><br />
+        <label><input name="main_q10_6" type="radio" value="Cover with tape"/> D. He should cover the wires with tape and continue working.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Drew picks up a metal rod near a sanding machine and then touches his forehead, leaving metallic dust on his skin.  
           What safety practice did Drew neglect, and what is the appropriate step when handling metal dust?</p>
-        <label><input data-correct="false" name="main_q10_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
+        <label><input name="main_q10_7" type="radio" value="Masking tape"/> A. He neglected to wear masking tape; he should tape dust away.</label><br />
         <label><input data-correct="true" name="main_q10_7" type="radio" value="Dust mask and gloves"/> B. He neglected wearing a dust mask and gloves; he should put on PPE (dust mask and gloves) before handling metal and wash his hands before touching his face.</label><br />
-        <label><input data-correct="false" name="main_q10_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
-        <label><input data-correct="false" name="main_q10_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
+        <label><input name="main_q10_7" type="radio" value="Ear protection"/> C. He neglected wearing ear protection; he should use ear muffs.</label><br />
+        <label><input name="main_q10_7" type="radio" value="Steel-toe boots"/> D. He neglected wearing steel-toe boots; he should swap footwear.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Nora adjusts the overhead fluorescent lights but stands on a rolling stool that moves as soon as she applies pressure.  
           What mistake is she making, and what is the safer alternative?</p>
-        <label><input data-correct="false" name="main_q10_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
+        <label><input name="main_q10_8" type="radio" value="Stand on stool"/> A. She should stand on the stool—higher is better.</label><br />
         <label><input data-correct="true" name="main_q10_8" type="radio" value="Use stepladder"/> B. Using a rolling stool is unstable; she should use a stable stepladder or platform with a flat, non-slip surface.</label><br />
-        <label><input data-correct="false" name="main_q10_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
-        <label><input data-correct="false" name="main_q10_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
+        <label><input name="main_q10_8" type="radio" value="Stack stools"/> C. She should stack stools to reach higher.</label><br />
+        <label><input name="main_q10_8" type="radio" value="Climb bench"/> D. She should climb on the bench—benches are sturdier.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Pat cleans a spilled solvent on the bench with a cloth but leaves the rag near an electrical outlet.  
           Why is placing a solvent-soaked rag near an electrical outlet hazardous, and what should Pat have done instead?</p>
-        <label><input data-correct="false" name="main_q10_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
+        <label><input name="main_q10_9" type="radio" value="Not flammable"/> A. It’s fine—solvent rags are not flammable.</label><br />
         <label><input data-correct="true" name="main_q10_9" type="radio" value="Flammable—flammables bin"/> B. Many solvents are flammable; he should place the rag in a designated metal “flammables” bin away from ignition sources.</label><br />
-        <label><input data-correct="false" name="main_q10_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
-        <label><input data-correct="false" name="main_q10_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
+        <label><input name="main_q10_9" type="radio" value="Leave on floor"/> C. He should instead leave it on the floor—closer to a window.</label><br />
+        <label><input name="main_q10_9" type="radio" value="Wash rag"/> D. He should wash the rag in cold water immediately.</label>
       </li>
       <li>
         <p><b>Scenario:</b> Quinn enters the workshop wearing open-toe sandals, despite signs requiring closed shoes. He proceeds to cut timber while focusing on aligning the blade.  
           What is the hazard of wearing sandals in the workshop, and what footwear should Quinn have chosen?</p>
         <label><input data-correct="true" name="main_q10_10" type="radio" value="Closed shoes"/> A. Sandals allow wood chips to land on feet—he should wear closed, non-slip leather shoes or safety boots.</label><br />
-        <label><input data-correct="false" name="main_q10_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
-        <label><input data-correct="false" name="main_q10_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
-        <label><input data-correct="false" name="main_q10_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
+        <label><input name="main_q10_10" type="radio" value="Rubber mats"/> B. Sandals are fine if he stays on rubber mats.</label><br />
+        <label><input name="main_q10_10" type="radio" value="Only welding"/> C. Sandals only matter during welding—he’s safe while cutting wood.</label><br />
+        <label><input name="main_q10_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
     <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 10')">Check Answers</button>


### PR DESCRIPTION
## Summary
- remove `data-correct="false"` attributes so only correct answers are flagged

## Testing
- `grep -n "data-correct=\"false\"" -n index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_683b87ca448083269fde5f79a5f4a348