### PR TITLE
Fix quiz answer evaluation bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -2726,7 +2726,7 @@ function submitQuiz(btn, quizType) {
     radios.forEach(radio => {
       if (radio.checked) {
         answered = true;
-        if (radio.hasAttribute('data-correct')) userCorrect = true;
+        if (radio.getAttribute('data-correct') === 'true') userCorrect = true;
       }
       // Reset label
       radio.parentElement.removeAttribute('data-result');


### PR DESCRIPTION
## Summary
- fix quiz logic so answers only count correct if `data-correct="true"`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683b903eae3483269a85064197bf347d