### PR TITLE
Fix Google Sheets submission CORS mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2770,7 +2770,7 @@ function submitQuiz(btn, quizType) {
   askForName().then(name => {
     fetch(SCRIPT_URL, {
       method: "POST",
-      mode: "cors",
+      mode: "no-cors",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         quizType,
@@ -2804,7 +2804,7 @@ function submitAdvancedQuiz(btn, quizType) {
 
   fetch(SCRIPT_URL, {
     method: 'POST',
-    mode: 'cors',
+    mode: 'no-cors',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       quizType,


### PR DESCRIPTION
## Summary
- update quiz submission requests to use `no-cors`

## Testing
- `npx --yes htmlhint index.html` *(fails: npm package download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_683bfe7578b083269bcef9ca470c1562