### PR TITLE
Fix missing quiz number field in results

### DIFF
--- a/index.html
+++ b/index.html
@@ -2768,12 +2768,20 @@ function submitQuiz(btn, quizType) {
   form.querySelector('.quiz-msg').textContent = msg;
 
   askForName().then(name => {
+    const numMatch = quizType.match(/Week\s*(\d+)/i);
+    const prefix = /Support/i.test(quizType)
+      ? 'S'
+      : /Advanced/i.test(quizType)
+      ? 'A'
+      : 'M';
+    const quizNumber = prefix + (numMatch ? numMatch[1] : '');
     fetch(SCRIPT_URL, {
       method: "POST",
       mode: "no-cors",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         quizType,
+        quizNumber,
         quiz: results,
         score: correct + "/" + total,
         studentName: name,
@@ -2802,12 +2810,20 @@ function submitAdvancedQuiz(btn, quizType) {
   form.querySelector('.quiz-msg').textContent =
     'Responses submitted. Your teacher will review them.';
 
+  const numMatch = quizType.match(/Week\s*(\d+)/i);
+  const prefix = /Support/i.test(quizType)
+    ? 'S'
+    : /Advanced/i.test(quizType)
+    ? 'A'
+    : 'M';
+  const quizNumber = prefix + (numMatch ? numMatch[1] : '');
   fetch(SCRIPT_URL, {
     method: 'POST',
     mode: 'no-cors',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       quizType,
+      quizNumber,
       studentName: studentName.trim(),
       responses,
       timestamp: new Date().toISOString()


### PR DESCRIPTION
## Summary
- include `quizNumber` when posting quiz results
- prefix quiz numbers with `M`, `S`, or `A` for main, support, or advanced quizzes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683c0d59f7c883269bca545a6065bf29