### PR TITLE
Ensure week links load in order

### DIFF
--- a/loadSections.js
+++ b/loadSections.js
@@ -25,22 +25,22 @@ function loadSections() {
   }));
 }
 
-function loadWeeks() {
+async function loadWeeks() {
+  async function fetchWeekSequential(section, count) {
+    const container = document.getElementById(section + '-weeks');
+    if (!container) return;
+    for (let i = 1; i <= count; i++) {
+      const resp = await fetch(`sections/${section}/week${i}.html`);
+      const html = await resp.text();
+      const div = document.createElement('div');
+      div.innerHTML = html;
+      container.appendChild(div);
+    }
+  }
+
   const promises = [];
   for (const [section, count] of Object.entries(weekCounts)) {
-    const container = document.getElementById(section + '-weeks');
-    if (!container) continue;
-    for (let i = 1; i <= count; i++) {
-      promises.push(
-        fetch(`sections/${section}/week${i}.html`)
-          .then(resp => resp.text())
-          .then(html => {
-            const div = document.createElement('div');
-            div.innerHTML = html;
-            container.appendChild(div);
-          })
-      );
-    }
+    promises.push(fetchWeekSequential(section, count));
   }
   return Promise.all(promises);
 }


### PR DESCRIPTION
## Summary
- fix `loadWeeks` so each week's HTML is appended sequentially

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871cdeab46c8326a1e451004f5b1fe2