### PR TITLE
Update quiz routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,13 +593,18 @@ function submitQuiz(btn, quizType) {
   form.querySelector('.quiz-msg').textContent = msg;
 
   askForName().then(name => {
-    const numMatch = quizType.match(/Week\s*(\d+)/i);
-    const prefix = /Support/i.test(quizType)
-      ? 'S'
-      : /Advanced/i.test(quizType)
-      ? 'A'
-      : 'M';
-    const quizNumber = prefix + (numMatch ? numMatch[1] : '');
+    let quizNumber = '';
+    if (/^[MSA]\d+/i.test(quizType)) {
+      quizNumber = quizType.toUpperCase();
+    } else {
+      const numMatch = quizType.match(/Week\s*(\d+)/i);
+      const prefix = /Support/i.test(quizType)
+        ? 'S'
+        : /Advanced/i.test(quizType)
+        ? 'A'
+        : 'M';
+      quizNumber = prefix + (numMatch ? String(numMatch[1]).padStart(3, '0') : '');
+    }
     fetch(SCRIPT_URL, {
       method: "POST",
       mode: "no-cors",
@@ -635,13 +640,18 @@ function submitAdvancedQuiz(btn, quizType) {
   form.querySelector('.quiz-msg').textContent =
     'Responses submitted. Your teacher will review them.';
 
-  const numMatch = quizType.match(/Week\s*(\d+)/i);
-  const prefix = /Support/i.test(quizType)
-    ? 'S'
-    : /Advanced/i.test(quizType)
-    ? 'A'
-    : 'M';
-  const quizNumber = prefix + (numMatch ? numMatch[1] : '');
+  let quizNumber = '';
+  if (/^[MSA]\d+/i.test(quizType)) {
+    quizNumber = quizType.toUpperCase();
+  } else {
+    const numMatch = quizType.match(/Week\s*(\d+)/i);
+    const prefix = /Support/i.test(quizType)
+      ? 'S'
+      : /Advanced/i.test(quizType)
+      ? 'A'
+      : 'M';
+    quizNumber = prefix + (numMatch ? String(numMatch[1]).padStart(3, '0') : '');
+  }
   fetch(SCRIPT_URL, {
     method: 'POST',
     mode: 'no-cors',

--- a/sections/advanced-activities/week1.html
+++ b/sections/advanced-activities/week1.html
@@ -21,7 +21,7 @@
                 <textarea class="wide-textarea" name="adv_q1_3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 1')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A001')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week10.html
+++ b/sections/advanced-activities/week10.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv10_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 10')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A010')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week2.html
+++ b/sections/advanced-activities/week2.html
@@ -21,7 +21,7 @@
                 <textarea class="wide-textarea" name="adv2_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 2')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A002')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week3.html
+++ b/sections/advanced-activities/week3.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv3_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 3')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A003')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week4.html
+++ b/sections/advanced-activities/week4.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv4_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 4')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A004')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week5.html
+++ b/sections/advanced-activities/week5.html
@@ -30,7 +30,7 @@
                 <textarea class="wide-textarea" name="adv5_q4" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 5')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A005')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week6.html
+++ b/sections/advanced-activities/week6.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv6_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 6')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A006')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week7.html
+++ b/sections/advanced-activities/week7.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv7_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 7')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A007')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week8.html
+++ b/sections/advanced-activities/week8.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv8_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 8')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A008')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/advanced-activities/week9.html
+++ b/sections/advanced-activities/week9.html
@@ -20,7 +20,7 @@
                 <textarea class="wide-textarea" name="adv9_q3" required></textarea>
               </li>
             </ol>
-            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'Advanced Content - Week 9')">Check Results</button>
+            <button class="check-advanced-btn" type="button" onclick="submitAdvancedQuiz(this, 'A009')">Check Results</button>
             <span class="quiz-msg"></span>
           </fieldset>
         </form>

--- a/sections/main-theory/week10.html
+++ b/sections/main-theory/week10.html
@@ -103,7 +103,7 @@
         <label><input data-correct="false" name="main_q10_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 10')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M010')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week2.html
+++ b/sections/main-theory/week2.html
@@ -93,7 +93,7 @@
         <label><input data-correct="false" name="main_q2_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 2')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M002')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week3.html
+++ b/sections/main-theory/week3.html
@@ -94,7 +94,7 @@
         <label><input data-correct="false" name="main_q3_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 3')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M003')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week4.html
+++ b/sections/main-theory/week4.html
@@ -90,7 +90,7 @@
         <label><input data-correct="false" name="main_q4_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 4')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M004')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week5.html
+++ b/sections/main-theory/week5.html
@@ -114,7 +114,7 @@
         <label><input data-correct="false" name="main_q5_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 5')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M005')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week6.html
+++ b/sections/main-theory/week6.html
@@ -103,7 +103,7 @@
         <label><input data-correct="false" name="main_q6_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 6')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M006')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week7.html
+++ b/sections/main-theory/week7.html
@@ -98,7 +98,7 @@
         <label><input data-correct="false" name="main_q7_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 7')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M007')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week8.html
+++ b/sections/main-theory/week8.html
@@ -91,7 +91,7 @@
         <label><input data-correct="false" name="main_q8_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 8')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M008')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/main-theory/week9.html
+++ b/sections/main-theory/week9.html
@@ -94,7 +94,7 @@
         <label><input data-correct="false" name="main_q9_10" type="radio" value="Stand still"/> D. Sandals are acceptable if he stands very still.</label>
       </li>
     </ol>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Main Theory Content - Week 9')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'M009')">Check Answers</button>
     <span class="quiz-msg"></span>
   </fieldset>
 </form>

--- a/sections/support-activities/week1.html
+++ b/sections/support-activities/week1.html
@@ -63,7 +63,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 1')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S001')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week10.html
+++ b/sections/support-activities/week10.html
@@ -59,7 +59,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 10')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S010')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week2.html
+++ b/sections/support-activities/week2.html
@@ -61,7 +61,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 2')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S002')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week3.html
+++ b/sections/support-activities/week3.html
@@ -61,7 +61,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 3')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S003')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week4.html
+++ b/sections/support-activities/week4.html
@@ -61,7 +61,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 4')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S004')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week5.html
+++ b/sections/support-activities/week5.html
@@ -61,7 +61,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 5')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S005')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week6.html
+++ b/sections/support-activities/week6.html
@@ -61,7 +61,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 6')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S006')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week7.html
+++ b/sections/support-activities/week7.html
@@ -59,7 +59,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 7')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S007')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week8.html
+++ b/sections/support-activities/week8.html
@@ -59,7 +59,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 8')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S008')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>

--- a/sections/support-activities/week9.html
+++ b/sections/support-activities/week9.html
@@ -59,7 +59,7 @@
             </li>
           </ol>
         </fieldset>
-    <button class="check-btn" type="button" onclick="submitQuiz(this, 'Support Theory Content - Week 9')">Check Answers</button>
+    <button class="check-btn" type="button" onclick="submitQuiz(this, 'S009')">Check Answers</button>
     <span class="quiz-msg"></span>
   
       </form>


### PR DESCRIPTION
## Summary
- allow direct quiz number syntax in `submitQuiz` and `submitAdvancedQuiz`
- send main theory results using IDs like `M002`
- send support theory results using IDs like `S001`
- send advanced theory results using IDs like `A004`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872f640ab4083269043d800dcce87e3