### PR TITLE
Investigate image rendering issues

### DIFF
--- a/sections/main-theory/week1.html
+++ b/sections/main-theory/week1.html
@@ -43,42 +43,42 @@
     <div class="image-cards">
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/Hard Hat.jpeg" alt="Hard hat for head protection">
+          <img src="../../Construction Pictures/Hard Hat.jpeg" alt="Hard hat for head protection">
           <figcaption>Hard Hat - Head Protection</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/High Vis' Cloths.jpeg" alt="High visibility clothing">
+          <img src="../../Construction Pictures/High Vis' Cloths.jpeg" alt="High visibility clothing">
           <figcaption>High Visibility Clothing</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/work boots.jpeg" alt="Safety work boots">
+          <img src="../../Construction Pictures/work boots.jpeg" alt="Safety work boots">
           <figcaption>Safety Work Boots</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/Work gloves.jpeg" alt="Work gloves for hand protection">
+          <img src="../../Construction Pictures/Work gloves.jpeg" alt="Work gloves for hand protection">
           <figcaption>Work Gloves - Hand Protection</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/ear muffs.jpeg" alt="Ear protection muffs">
+          <img src="../../Construction Pictures/ear muffs.jpeg" alt="Ear protection muffs">
           <figcaption>Ear Protection Muffs</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/Respirator.jpeg" alt="Respirator for dust protection">
+          <img src="../../Construction Pictures/Respirator.jpeg" alt="Respirator for dust protection">
           <figcaption>Respirator - Dust Protection</figcaption>
         </figure>
       </div>
@@ -90,28 +90,28 @@
     <div class="image-cards">
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/Danger sign.png" alt="Danger warning sign">
+          <img src="../../Construction Pictures/Danger sign.png" alt="Danger warning sign">
           <figcaption>Danger Warning Sign</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/Fire Blanket.png" alt="Fire blanket for emergencies">
+          <img src="../../Construction Pictures/Fire Blanket.png" alt="Fire blanket for emergencies">
           <figcaption>Fire Blanket - Emergency Equipment</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/Fire hydrant.png" alt="Fire hydrant location">
+          <img src="../../Construction Pictures/Fire hydrant.png" alt="Fire hydrant location">
           <figcaption>Fire Hydrant Location</figcaption>
         </figure>
       </div>
       
       <div class="image-card">
         <figure>
-          <img src="../Construction Pictures/fire exit.jpeg" alt="Fire exit sign">
+          <img src="../../Construction Pictures/fire exit.jpeg" alt="Fire exit sign">
           <figcaption>Fire Exit Sign</figcaption>
         </figure>
       </div>

--- a/sections/main-theory/week2.html
+++ b/sections/main-theory/week2.html
@@ -13,42 +13,42 @@
       <div class="image-cards">
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Tape measure.jpeg" alt="Tape measure for accurate measurements">
+            <img src="../../Construction Pictures/Tape measure.jpeg" alt="Tape measure for accurate measurements">
             <figcaption>Tape Measure - Accurate Measurements</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/steel rule.jpeg" alt="Steel rule for precise marking">
+            <img src="../../Construction Pictures/steel rule.jpeg" alt="Steel rule for precise marking">
             <figcaption>Steel Rule - Precise Marking</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/claw hammer.jpeg" alt="Claw hammer for assembly">
+            <img src="../../Construction Pictures/claw hammer.jpeg" alt="Claw hammer for assembly">
             <figcaption>Claw Hammer - Assembly</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Beveled edge chisel.jpeg" alt="Chisel for woodworking joints">
+            <img src="../../Construction Pictures/Beveled edge chisel.jpeg" alt="Chisel for woodworking joints">
             <figcaption>Chisel - Woodworking Joints</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Handplane.jpeg" alt="Hand plane for surface finishing">
+            <img src="../../Construction Pictures/Handplane.jpeg" alt="Hand plane for surface finishing">
             <figcaption>Hand Plane - Surface Finishing</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/F-Clamps.jpeg" alt="F-clamps for holding workpieces">
+            <img src="../../Construction Pictures/F-Clamps.jpeg" alt="F-clamps for holding workpieces">
             <figcaption>F-Clamps - Holding Workpieces</figcaption>
           </figure>
         </div>
@@ -60,28 +60,28 @@
       <div class="image-cards">
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Battery Drill.jpeg" alt="Battery drill for drilling holes">
+            <img src="../../Construction Pictures/Battery Drill.jpeg" alt="Battery drill for drilling holes">
             <figcaption>Battery Drill - Drilling Holes</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Circular Saw.jpeg" alt="Circular saw for cutting timber">
+            <img src="../../Construction Pictures/Circular Saw.jpeg" alt="Circular saw for cutting timber">
             <figcaption>Circular Saw - Cutting Timber</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Electric Plane.jpeg" alt="Electric plane for surface preparation">
+            <img src="../../Construction Pictures/Electric Plane.jpeg" alt="Electric plane for surface preparation">
             <figcaption>Electric Plane - Surface Preparation</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Bench Grinder.jpeg" alt="Bench grinder for tool sharpening">
+            <img src="../../Construction Pictures/Bench Grinder.jpeg" alt="Bench grinder for tool sharpening">
             <figcaption>Bench Grinder - Tool Sharpening</figcaption>
           </figure>
         </div>
@@ -93,28 +93,28 @@
       <div class="image-cards">
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Lengths of timber.jpeg" alt="Timber lengths for construction">
+            <img src="../../Construction Pictures/Lengths of timber.jpeg" alt="Timber lengths for construction">
             <figcaption>Timber Lengths - Main Construction Material</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Timber Length.jpeg" alt="Individual timber piece">
+            <img src="../../Construction Pictures/Timber Length.jpeg" alt="Individual timber piece">
             <figcaption>Individual Timber Piece</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/tins of paint.jpeg" alt="Paint for finishing">
+            <img src="../../Construction Pictures/tins of paint.jpeg" alt="Paint for finishing">
             <figcaption>Paint - Surface Finishing</figcaption>
           </figure>
         </div>
         
         <div class="image-card">
           <figure>
-            <img src="../Construction Pictures/Extension lead.jpeg" alt="Extension lead for power tools">
+            <img src="../../Construction Pictures/Extension lead.jpeg" alt="Extension lead for power tools">
             <figcaption>Extension Lead - Power Supply</figcaption>
           </figure>
         </div>

--- a/sections/main-theory/week7.html
+++ b/sections/main-theory/week7.html
@@ -18,28 +18,28 @@
           <div class="image-cards">
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/Battery drill (2).jpeg" alt="Battery drill for driving screws">
+                <img src="../../Construction Pictures/Battery drill (2).jpeg" alt="Battery drill for driving screws">
                 <figcaption>Battery Drill - Driving Screws</figcaption>
               </figure>
             </div>
             
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/Unility knife.jpeg" alt="Utility knife for marking">
+                <img src="../../Construction Pictures/Unility knife.jpeg" alt="Utility knife for marking">
                 <figcaption>Utility Knife - Precise Marking</figcaption>
               </figure>
             </div>
             
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/Clawhammer.jpeg" alt="Claw hammer for nails">
+                <img src="../../Construction Pictures/Clawhammer.jpeg" alt="Claw hammer for nails">
                 <figcaption>Claw Hammer - Nail Driving</figcaption>
               </figure>
             </div>
             
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/Sharpening wheel.jpeg" alt="Sharpening wheel for tools">
+                <img src="../../Construction Pictures/Sharpening wheel.jpeg" alt="Sharpening wheel for tools">
                 <figcaption>Sharpening Wheel - Tool Maintenance</figcaption>
               </figure>
             </div>
@@ -51,21 +51,21 @@
           <div class="image-cards">
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/Work gloves.jpeg" alt="Work gloves for hand protection">
+                <img src="../../Construction Pictures/Work gloves.jpeg" alt="Work gloves for hand protection">
                 <figcaption>Work Gloves - Hand Protection</figcaption>
               </figure>
             </div>
             
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/ear muffs.jpeg" alt="Ear protection for power tools">
+                <img src="../../Construction Pictures/ear muffs.jpeg" alt="Ear protection for power tools">
                 <figcaption>Ear Protection - Power Tool Safety</figcaption>
               </figure>
             </div>
             
             <div class="image-card">
               <figure>
-                <img src="../Construction Pictures/Respirator.jpeg" alt="Respirator for dust protection">
+                <img src="../../Construction Pictures/Respirator.jpeg" alt="Respirator for dust protection">
                 <figcaption>Respirator - Dust Protection</figcaption>
               </figure>
             </div>


### PR DESCRIPTION
Fix broken image paths in HTML files by correcting relative directory references.

The original paths like `../Construction Pictures/` were incorrect because the `Construction Pictures/` directory is located at the repository root, not one level up from `sections/main-theory/`. The paths have been updated to `../../Construction Pictures/` to correctly navigate two levels up to the root.

---
<a href="https://cursor.com/background-agent?bcId=bc-817938d2-d7d7-4980-88f4-6aea7fe53eaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-817938d2-d7d7-4980-88f4-6aea7fe53eaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

